### PR TITLE
run python scripts in uv venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ all: $(FINAL_GEOJSON)
 $(FINAL_GEOJSON): scripts/downloadFile.py scripts/convertGeoJSON.py $(SUPPORTED_VARIANT_LOCS)
 	@echo "==> Preparing $@"
 	@mkdir -p $(dir $@) $(SHPDIR)
-	python3 scripts/downloadFile.py $(URL) $(ZIP) $(SHP)
-	python3 scripts/convertGeoJSON.py --input $(SHP) --output $(FINAL_GEOJSON) --variant-loc-yaml $(SUPPORTED_VARIANT_LOCS)
+	uv run python scripts/downloadFile.py $(URL) $(ZIP) $(SHP)
+	uv run python scripts/convertGeoJSON.py --input $(SHP) --output $(FINAL_GEOJSON) --variant-loc-yaml $(SUPPORTED_VARIANT_LOCS)
 	@echo "==> Cleaning intermediates"
 	@rm -rf $(MAKE_TMP)
 	@echo "==> Done. Kept: $(SUPPORTED_VARIANT_LOCS)"


### PR DESCRIPTION
Closes #43 

The Makefile now calls python scripts in the `uv` virtual environment to circumvent issues with local dependencies. 

One catch: it is required to run this after setting up uv. I think that's okay because A) the cloned repo contains a uv setup and B) the instructions say to install uv before this step in the setup process. 

Warning: It might take a tad longer due to the `uv` overhead but this isn't really a bottleneck because `make` is not frequently run. 